### PR TITLE
feat: Discord username verification

### DIFF
--- a/pftpyclient/utilities/task_manager.py
+++ b/pftpyclient/utilities/task_manager.py
@@ -21,6 +21,7 @@ import xrpl
 from xrpl.models.requests import AccountTx
 from xrpl.models.transactions import Memo
 from xrpl.utils import str_to_hex
+from xrpl.core.keypairs import sign
 import nest_asyncio
 import pandas as pd
 import numpy as np
@@ -99,6 +100,22 @@ class PostFiatTaskManager:
         # By default, the wallet is considered UNFUNDED
         self.wallet_state = WalletState.UNFUNDED
         self.determine_wallet_state()
+
+    def sign_message(self, message: str) -> tuple[str, str]:
+        """Signs a message using the wallet's private key
+        
+        Args:
+            message: The message to sign
+            
+        Returns:
+            tuple[str, str]: (signature, public_key)
+        """
+        try:
+            signature = sign(message.encode(), self.user_wallet.private_key)
+            return signature, self.user_wallet.public_key
+        except Exception as e:
+            logger.error(f"Error signing message: {e}")
+            raise
 
     def get_xrp_balance(self):
         return get_xrp_balance(self.network_url, self.user_wallet.classic_address)

--- a/pftpyclient/version.py
+++ b/pftpyclient/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.2.3'
+VERSION = '0.2.4'

--- a/pftpyclient/wallet_ux/dialogs.py
+++ b/pftpyclient/wallet_ux/dialogs.py
@@ -1108,6 +1108,19 @@ class CustomDialog(wx.Dialog):
         wx.CallAfter(self.close_button.SetFocus)
 
     def OnSubmit(self, e: wx.CommandEvent) -> None:
+        # Check for empty values in text controls
+        for field, control in self.text_controls.items():
+            if isinstance(control, wx.TextCtrl):
+                value = control.GetValue().strip()
+                if not value:
+                    wx.MessageBox(
+                        f"Please enter a value for {field}",
+                        "Required Field",
+                        wx.OK | wx.ICON_WARNING
+                    )
+                    control.SetFocus()
+                    return
+
         self.EndModal(wx.ID_OK)
 
     def OnClose(self, e: wx.CommandEvent) -> None:

--- a/pftpyclient/wallet_ux/prod_wallet.py
+++ b/pftpyclient/wallet_ux/prod_wallet.py
@@ -512,6 +512,7 @@ class WalletApp(wx.Frame):
         self.change_password_item = self.account_menu.Append(wx.ID_ANY, "Change Password")
         self.show_secret_item = self.account_menu.Append(wx.ID_ANY, "Show Secret")
         self.update_trustline_item = self.account_menu.Append(wx.ID_ANY, "Update Trustline")
+        self.verify_discord_item = self.account_menu.Append(wx.ID_ANY, "Verify Discord")
         self.delete_account_item = self.account_menu.Append(wx.ID_ANY, "Delete Account")
         self.menubar.Append(self.account_menu, "Account")
 
@@ -521,6 +522,7 @@ class WalletApp(wx.Frame):
         self.Bind(wx.EVT_MENU, self.on_change_password, self.change_password_item)
         self.Bind(wx.EVT_MENU, self.on_show_secret, self.show_secret_item)
         self.Bind(wx.EVT_MENU, self.on_update_trustline, self.update_trustline_item)
+        self.Bind(wx.EVT_MENU, self.on_verify_discord, self.verify_discord_item)
         self.Bind(wx.EVT_MENU, self.on_delete_credentials, self.delete_account_item)
 
         # Extras menu
@@ -1652,6 +1654,7 @@ class WalletApp(wx.Frame):
 
         match current_state:
             case WalletState.UNFUNDED:
+                # Funding the wallet
                 message = (
                     "To activate your wallet, you need \nto send at least 1 XRP to your address. \n\n"
                     f"Your XRP address:\n\n{self.wallet.classic_address}\n\n"
@@ -1661,6 +1664,7 @@ class WalletApp(wx.Frame):
                 dialog.Destroy()
 
             case WalletState.FUNDED:
+                # Setting the trust line
                 message = (
                     "Your wallet needs a trust line to handle PFT tokens.\n\n"
                     "This transaction will:\n"
@@ -1678,8 +1682,18 @@ class WalletApp(wx.Frame):
                         wx.MessageBox(f"Error setting trust line: {e}", "Error", wx.OK | wx.ICON_ERROR)
 
             case WalletState.TRUSTLINED:
+                # Discord verification
+                if not self.handle_discord_verification(prompt_for_confirmation=True):
+                    wx.MessageBox(
+                        "Please complete Discord verification before proceeding with the Initiation Rite.", 
+                        "Verification Required", 
+                        wx.OK | wx.ICON_INFORMATION
+                    )
+                    return
+
+                # Initiation Rite
                 message = (
-                    "To start accepting tasks, you need to perform the Initiation Rite.\n\n"
+                    "Once your address has been verified with the node, you can perform the Initiation Rite.\n\n"
                     "This transaction will cost 1 XRP.\n\n"
                     "Please write 1 sentence committing to a long term objective of your choice:"
                 )
@@ -1700,6 +1714,7 @@ class WalletApp(wx.Frame):
                 dialog.Destroy()
 
             case WalletState.INITIATED:
+                # Initiating an encrypted channel via a request to the node
                 message = (
                     "To continue with wallet initialization,\n"
                     "you need to establish secure communication with the network.\n\n"
@@ -1723,6 +1738,7 @@ class WalletApp(wx.Frame):
                         wx.MessageBox(f"Error sending handshake: {e}", "Error", wx.OK | wx.ICON_ERROR)
 
             case WalletState.HANDSHAKE_SENT:
+                # Finalizing the encrypted channel via a response from the node
                 message = (
                     "Waiting for handshake response from node to establish encrypted channel.\n\n"
                     "This will only take a moment."
@@ -1730,6 +1746,7 @@ class WalletApp(wx.Frame):
                 wx.MessageBox(message, "Waiting for Handshake", wx.OK | wx.ICON_INFORMATION)
 
             case WalletState.HANDSHAKE_RECEIVED:
+                # Setting up the Google Doc
                 if self.show_google_doc_template(is_initial_setup=True):
                     self.handle_google_doc_submission(event, is_initial_setup=True)
                     self.start_wallet_state_monitoring()
@@ -3170,6 +3187,60 @@ class WalletApp(wx.Frame):
             
             self.worker = XRPLMonitorThread(self)
             self.worker.start()
+
+    def handle_discord_verification(self, prompt_for_confirmation: bool = False) -> bool:
+        """Handle the Discord verification process
+        
+        Returns:
+            bool: True if verification was completed, False otherwise
+        """
+        message = (
+            "To interact with the Post Fiat Task Node, you need to verify your address via Discord.\n\n"
+            "The Post Fiat Task Node requires that you tie this address to your Discord account.\n\n"
+            "Please enter your Discord username below:"
+        )
+        dialog = CustomDialog(self, "Verify Address", ["Discord Username"], message=message)
+        if dialog.ShowModal() != wx.ID_OK:
+            dialog.Destroy()
+            return False
+
+        discord_username = dialog.GetValues()["Discord Username"]
+        dialog.Destroy()
+
+        try:
+            # Sign the Discord username
+            signature, public_key = self.task_manager.sign_message(discord_username)
+
+            # Display verification instructions in a selectable dialog
+            verification_message = (
+                f"Please verify your address in Discord (using the pf_verify command) with the following information:\n\n"
+                f"Discord Username:\n{discord_username}\n\n"
+                f"XRP Address:\n{self.wallet.classic_address}\n\n"
+                f"Signature:\n{signature}\n\n"
+                f"Public Key:\n{public_key}\n\n"
+            )
+            
+            dialog = SelectableMessageDialog(self, "Discord Verification", verification_message)
+            dialog.ShowModal()
+            dialog.Destroy()
+
+            if prompt_for_confirmation:
+                return wx.YES == wx.MessageBox(
+                    "Have you completed the Discord verification?",
+                    "Verification Confirmation",
+                    wx.YES_NO | wx.ICON_QUESTION
+                )
+            else:
+                return True
+
+        except Exception as e:
+            logger.error(f"Error during Discord address verification: {e}")
+            wx.MessageBox(f"Error during Discord address verification: {e}", "Error", wx.OK | wx.ICON_ERROR)
+            return False
+
+    def on_verify_discord(self, event):
+        """Handle the Verify Discord menu item"""
+        self.handle_discord_verification()
 
 def main():
     logger.info("Starting Post Fiat Wallet")

--- a/pftpyclient/wallet_ux/prod_wallet.py
+++ b/pftpyclient/wallet_ux/prod_wallet.py
@@ -513,6 +513,7 @@ class WalletApp(wx.Frame):
         self.show_secret_item = self.account_menu.Append(wx.ID_ANY, "Show Secret")
         self.update_trustline_item = self.account_menu.Append(wx.ID_ANY, "Update Trustline")
         self.verify_discord_item = self.account_menu.Append(wx.ID_ANY, "Verify Discord")
+        self.send_handshake_item = self.account_menu.Append(wx.ID_ANY, "Send Handshake")
         self.delete_account_item = self.account_menu.Append(wx.ID_ANY, "Delete Account")
         self.menubar.Append(self.account_menu, "Account")
 
@@ -523,6 +524,7 @@ class WalletApp(wx.Frame):
         self.Bind(wx.EVT_MENU, self.on_show_secret, self.show_secret_item)
         self.Bind(wx.EVT_MENU, self.on_update_trustline, self.update_trustline_item)
         self.Bind(wx.EVT_MENU, self.on_verify_discord, self.verify_discord_item)
+        self.Bind(wx.EVT_MENU, self.on_send_handshake, self.send_handshake_item)
         self.Bind(wx.EVT_MENU, self.on_delete_credentials, self.delete_account_item)
 
         # Extras menu
@@ -3241,6 +3243,19 @@ class WalletApp(wx.Frame):
     def on_verify_discord(self, event):
         """Handle the Verify Discord menu item"""
         self.handle_discord_verification()
+
+    def on_send_handshake(self, event):
+        message = "Send a handshake to an address"
+        handshake_dialog = CustomDialog(self, "Handshake", ["Address"], message=message)
+        if handshake_dialog.ShowModal() == wx.ID_OK:
+            address = handshake_dialog.GetValues()["Address"]
+            handshake_dialog.Destroy()
+            logger.debug(f"Sending handshake to {address}")
+            response = self.task_manager.send_handshake(destination=address)
+            formatted_response = self.format_response(response)
+            dialog = SelectableMessageDialog(self, "Handshake Submission Result", formatted_response)
+            dialog.ShowModal()
+            dialog.Destroy()
 
 def main():
     logger.info("Starting Post Fiat Wallet")


### PR DESCRIPTION
Version 0.2.4
* Added discord username signing utility to enable verification of external addresses through TaskNode's Discord `/pf_verify` command
* Added Send Handshake menu item to handle the edge case when a user sends a handshake before verifying their address through Discord, resulting in a state where they can't resend the handshake through the Encryption Requests dialog. The username verification is now part of the user-creation flow and a user will have to willingly ignore the verification step for this edge case to occur. 